### PR TITLE
Adding events from burellka Commit 2bca5e9

### DIFF
--- a/custom_components/tplink_deco/device_tracker.py
+++ b/custom_components/tplink_deco/device_tracker.py
@@ -332,6 +332,7 @@ class TplinkDecoClientDeviceTracker(CoordinatorEntity, RestoreEntity, ScannerEnt
         self._client_prefix = client_prefix
         self._coordinator_decos = coordinator_decos
         self._mac_address = client.mac
+        self._last_connected_state = client.online  # Track last connection state
         self._update_from_client()
         super().__init__(coordinator_clients)
 
@@ -405,8 +406,23 @@ class TplinkDecoClientDeviceTracker(CoordinatorEntity, RestoreEntity, ScannerEnt
         await self.coordinator.async_request_refresh()
 
     @callback
+    def _fire_device_event(self, connected: bool) -> None:
+        self.hass.bus.async_fire("tplink_deco_device_event", {
+            "mac": self._client.mac,
+            "name": self._client.name,
+            "state": "connected" if connected else "disconnected",
+        })
+
+    @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        was_connected = self._last_connected_state
+        is_now_connected = self._client.online
+
+        if is_now_connected != was_connected:
+            self._fire_device_event(is_now_connected)
+            self._last_connected_state = is_now_connected
+
         if self._update_from_client():
             self.async_write_ha_state()
 

--- a/custom_components/tplink_deco/device_tracker.py
+++ b/custom_components/tplink_deco/device_tracker.py
@@ -420,7 +420,13 @@ class TplinkDecoClientDeviceTracker(CoordinatorEntity, RestoreEntity, ScannerEnt
         is_now_connected = self._client.online
 
         if is_now_connected != was_connected:
-            self._fire_device_event(is_now_connected)
+            event_data = {
+                "mac": self._mac_address,
+                "name": self._attr_name,
+                "state": "connected" if is_now_connected else "disconnected",
+            }
+            _LOGGER.warning("[DecoClientDeviceTracker] Firing event: %s", event_data)
+            self.hass.bus.async_fire("tplink_deco_device_event", event_data)
             self._last_connected_state = is_now_connected
 
         if self._update_from_client():


### PR DESCRIPTION
feat(device_tracker): Emit custom events on client connect/disconnect
- Added event firing via `tplink_deco_device_event` when a Deco client device connects or disconnects.
- Included device MAC, name, and connection state in the event payload.
- Helpful for integrating external systems or triggering automations in Home Assistant.

docs: Add example automation for handling deco device connection events

- Documented the `tplink_deco_device_event` with sample payload structure.
- Included a practical automation example to trigger an external HTTP endpoint when a client connects.
- Supports flexible integrations beyond Pi-hole (e.g., logging, device registration, notifications).